### PR TITLE
Removing php 5.3 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
 


### PR DESCRIPTION
Sorry, I haven't see in composer that minimum version is 5.4 so i have removed the tests for 5.3
